### PR TITLE
Top up functionality

### DIFF
--- a/app/bunq.py
+++ b/app/bunq.py
@@ -163,7 +163,6 @@ def retrieve_accounts(config):
     config["accounts"] = []
     result = get("v1/user/{}/monetary-account".format(config["user_id"]),
                  config)
-    print(result)
     for res in result["Response"]:
         for typ in res:
             acc = res[typ]
@@ -178,6 +177,7 @@ def retrieve_accounts(config):
                        "name": name,
                        "type": type_url,
                        "id": acc["id"],
+                       "balance": acc["balance"]["value"],
                        "description": acc["description"]}
             config["accounts"].append(accinfo)
 

--- a/app/bunq.py
+++ b/app/bunq.py
@@ -163,6 +163,7 @@ def retrieve_accounts(config):
     config["accounts"] = []
     result = get("v1/user/{}/monetary-account".format(config["user_id"]),
                  config)
+    print(result)
     for res in result["Response"]:
         for typ in res:
             acc = res[typ]

--- a/app/main.py
+++ b/app/main.py
@@ -498,6 +498,12 @@ def ifttt_account_options_topup_source():
     """ Option values for topup source account selection"""
     return ifttt_account_options(False, "Internal")
 
+@app.route("/ifttt/v1/actions/bunq_topup/fields/"\
+           "target_account/options", methods=["POST"])
+def ifttt_account_options_topup_target():
+    """ Option values for topup target account selection"""
+    return ifttt_account_options(False, None)
+
 @app.route("/ifttt/v1/actions/bunq_change_card_account/fields/"\
            "account/options", methods=["POST"])
 def ifttt_account_options_change_card():

--- a/app/main.py
+++ b/app/main.py
@@ -269,6 +269,12 @@ def ifttt_test_setup():
                         "target_name": "John Doe",
                         "description": "x",
                     },
+                   "bunq_topup": {
+                        "amount": "1.23",
+                        "source_account": test_account,
+                        "target_account": test_account,
+                        "description": "x",
+                    },
                     "bunq_change_card_account": {
                         "card": "x",
                         "account": test_account,
@@ -300,6 +306,12 @@ def ifttt_test_setup():
                         "source_account": test_account,
                         "target_account": test_account,
                         "target_name": "John Doe",
+                        "description": "x",
+                    },
+                    "bunq_topup": {
+                        "amount": "-1.23",
+                        "source_account": test_account,
+                        "target_account": test_account,
                         "description": "x",
                     },
                 }
@@ -479,6 +491,12 @@ def ifttt_account_options_draft():
 def ifttt_account_options_external():
     """ Option values for draft payment source account selection"""
     return ifttt_account_options(False, "External")
+
+@app.route("/ifttt/v1/actions/bunq_topup/fields/"\
+           "source_account/options", methods=["POST"])
+def ifttt_account_options_topup_source():
+    """ Option values for topup source account selection"""
+    return ifttt_account_options(False, "Internal")
 
 @app.route("/ifttt/v1/actions/bunq_change_card_account/fields/"\
            "account/options", methods=["POST"])
@@ -667,6 +685,13 @@ def ifttt_draft_payment():
         return errmsg, 401
     return payment.ifttt_bunq_payment(internal=False, draft=True)
 
+@app.route("/ifttt/v1/actions/bunq_topup", methods=["POST"])
+def ifttt_topup():
+    """ Execute an top up action """
+    errmsg = check_ifttt_service_key()
+    if errmsg:
+        return errmsg, 401
+    return payment.ifttt_bunq_topup(internal=True, draft=False)
 
 ###############################################################################
 # Change card account action endpoints


### PR DESCRIPTION
To be able to budget on seperate accounts sometimes you want to 'top up' your account to a certain amount. For example every month I want to be able to spend 50€ on beer from my beer account. 

In IFTTT you can create montly triggers but it is currently not possible to top up your account from a savings account (or any other) to a certain dedicated account. 

This pull request creates this functionality. What is still missing is:
- Documentation for the wiki
- A more efficient way to fetch the balance of the target monetary account (currently this goes via updating all bunq accounts)